### PR TITLE
fix(connection): bug in changing sql flavor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dataops-testgen"
-version = "2.24.7"
+version = "2.24.8"
 description = "DataKitchen's Data Quality DataOps TestGen"
 authors = [
     { "name" = "DataKitchen, Inc.", "email" = "info@datakitchen.io" },

--- a/testgen/ui/views/connections/page.py
+++ b/testgen/ui/views/connections/page.py
@@ -76,7 +76,8 @@ class ConnectionsPage(Page):
 
     def show_connection_form(self, selected_connection: dict, _mode: str, project_code) -> None:
         connection = selected_connection or {}
-        connection_id = connection.get("connection_id", None)
+        connection_id = connection.get("connection_id", 1)
+        connection_name = connection.get("connection_name", "default")
         sql_flavor = connection.get("sql_flavor", "postgresql")
         data = {}
 
@@ -84,18 +85,19 @@ class ConnectionsPage(Page):
             FlavorForm = BaseConnectionForm.for_flavor(sql_flavor)
             if connection:
                 connection["password"] = connection["password"] or ""
-                FlavorForm = BaseConnectionForm.for_flavor(sql_flavor)
-
-            form_kwargs = connection or {"sql_flavor": sql_flavor}
+                
+            form_kwargs = connection or {"sql_flavor": sql_flavor, "connection_id": connection_id, "connection_name": connection_name}
             form = FlavorForm(**form_kwargs)
 
             sql_flavor = form.get_field_value("sql_flavor", latest=True) or sql_flavor
             if form.sql_flavor != sql_flavor:
-                form = BaseConnectionForm.for_flavor(sql_flavor)(sql_flavor=sql_flavor)
+                form = BaseConnectionForm.for_flavor(sql_flavor)(sql_flavor=sql_flavor, connection_id=connection_id)
+
+            form.disable("connection_name")
 
             form_errors_container = st.empty()
             data = sp.pydantic_input(
-                key=f"connection_form:{connection_id or 'new'}",
+                key=f"connection_form:{connection_id}",
                 model=form,  # type: ignore
             )
             data.update({
@@ -120,16 +122,16 @@ class ConnectionsPage(Page):
             st.error("Unexpected error displaying the form. Try again")
 
         test_button_column, _, save_button_column = st.columns([.2, .6, .2])
-        is_submitted, set_submitted = temp_value(f"connection_form-{connection_id or 'new'}:submit")
-        get_connection_status, set_connection_status = temp_value(
-            f"connection_form-{connection_id or 'new'}:test_conn"
+        is_submitted, set_submitted = temp_value(f"connection_form-{connection_id}:submit")
+        is_connecting, set_connecting = temp_value(
+            f"connection_form-{connection_id}:test_conn"
         )
 
         with save_button_column:
             testgen.button(
                 type_="flat",
                 label="Save",
-                key=f"connection_form:{connection_id or 'new'}:submit",
+                key=f"connection_form:{connection_id}:submit",
                 on_click=lambda: set_submitted(True),
             )
 
@@ -138,13 +140,14 @@ class ConnectionsPage(Page):
                 type_="stroked",
                 color="basic",
                 label="Test Connection",
-                key=f"connection_form:{connection_id or 'new'}:test",
-                on_click=lambda: set_connection_status(self.test_connection(data)),
+                key=f"connection_form:{connection_id}:test",
+                on_click=lambda: set_connecting(True),
             )
 
-        if (connection_status := get_connection_status()):
+        if is_connecting():
             single_element_container = st.empty()
             single_element_container.info("Connecting ...")
+            connection_status = self.test_connection(data)
 
             with single_element_container.container():
                 renderer = {


### PR DESCRIPTION
- Consolidated the connection form and widget keys to always use the same connection ID, since there is only one connection. Otherwise the form key was changing between "new" and "1" when the SQL flavor was changed, and the form was not keeping the correct state.
- Updated the Test Connection button to use the data on the next rerun. Otherwise, if the button was clicked immediately after changing a field (without unfocusing the input), the latest change was not used for validating the connection.
- Disabled the "connection name" field for simplicity since there is only one connection.